### PR TITLE
Add page transitions

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<script>
+	  // Apply dark mode immediately to prevent flash
+	  if (localStorage.theme === 'dark' ||
+	    (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+	    document.documentElement.classList.add('dark');
+	  }
+	</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
@@ -45,7 +53,7 @@
     <link rel="alternate" type="application/atom+xml" title="Links Feed" href="/links/feed.xml">
     <!--<script defer src="https://cloud.umami.is/script.js" data-website-id="5a0a578b-bf79-4578-96ef-373454590774"></script>-->
 </head>
-<body class="min-h-screen bg-beige dark:bg-[#222] text-gray-900 dark:text-gray-100 font-sans overflow-x-hidden">
+<body class="min-h-screen font-sans overflow-x-hidden">
     <!-- Background layer -->
     <div id="page-background" class="fixed inset-0 -z-10 {{ bodyClass }}"></div>
 

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -18,7 +18,7 @@
     {% endif %}</title>
     <meta name="description" content="{{ description or site.description }}">
     <link rel="stylesheet" href="/css/style.css">
-    
+
     <!-- Pre-load font files -->
     <link rel="preload" href="/assets/fonts/Blanco-Regular.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Blanco-Medium.woff" as="font" type="font/woff" crossorigin>
@@ -26,7 +26,7 @@
     <link rel="preload" href="/assets/fonts/Blanco-Italic.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Blanco-MediumItalic.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/assets/fonts/Blanco-MediumItalic.woff" as="font" type="font/woff" crossorigin>
-    
+
     <link rel="preload" href="/assets/fonts/Degular-Regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-Regular.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-Medium.woff2" as="font" type="font/woff2" crossorigin>
@@ -35,32 +35,37 @@
     <link rel="preload" href="/assets/fonts/Degular-Italic.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-MediumItalic.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-MediumItalic.woff" as="font" type="font/woff" crossorigin>
-    
+
     <meta name="theme-color" content="#fcfaf6">
-    
+
+    <meta name="view-transition" content="same-origin">
+
     <!-- RSS Feeds -->
     <link rel="alternate" type="application/atom+xml" title="Journal Feed" href="/journal/feed.xml">
     <link rel="alternate" type="application/atom+xml" title="Links Feed" href="/links/feed.xml">
     <!--<script defer src="https://cloud.umami.is/script.js" data-website-id="5a0a578b-bf79-4578-96ef-373454590774"></script>-->
 </head>
-<body class="min-h-screen bg-beige dark:bg-[#222] text-gray-900 dark:text-gray-100 font-sans overflow-x-hidden {{ bodyClass }}">
-    {% include "header.njk" %}
+<body class="min-h-screen bg-beige dark:bg-[#222] text-gray-900 dark:text-gray-100 font-sans overflow-x-hidden">
+    <!-- Background layer -->
+    <div id="page-background" class="fixed inset-0 -z-10 {{ bodyClass }}"></div>
 
-    <nav class="fixed bottom-4 left-4 right-4 z-50 sm:bottom-6 sm:left-6 sm:right-auto">
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg py-4 px-4 sm:bg-transparent sm:dark:bg-transparent sm:border-0 sm:p-0 relative overflow-hidden">
-            <div class="absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white dark:from-gray-900 to-transparent pointer-events-none sm:hidden"></div>
-            {% include "navigation.njk" %}
-        </div>
-    </nav>
-    
-    <main class="ml-0 lg:ml-80 mr-0 lg:mr-32 pt-20 px-6 lg:px-12 flex-1 flex justify-end max-w-[1400px]">
-        <div class="w-full max-w-[1400px]">
-            {{ content | safe }}
-        </div>
-    </main>
+    <!-- Content wrapper -->
+    <div id="page-content">
+        {% include "header.njk" %}
 
-    
+        <nav class="fixed z-50 bottom-4 left-4 right-4 sm:bottom-6 sm:left-6 sm:right-auto">
+            <div class="relative px-4 py-4 overflow-hidden bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:border-gray-700 sm:bg-transparent sm:dark:bg-transparent sm:border-0 sm:p-0">
+                <div class="absolute inset-y-0 right-0 w-12 pointer-events-none bg-gradient-to-l from-white dark:from-gray-900 to-transparent sm:hidden"></div>
+                {% include "navigation.njk" %}
+            </div>
+        </nav>
+
+        <main class="ml-0 lg:ml-80 mr-0 lg:mr-32 pt-20 px-6 lg:px-12 flex-1 flex justify-end max-w-[1400px]">
+            <div class="w-full max-w-[1400px]">
+                {{ content | safe }}
+            </div>
+        </main>
+    </div>
+
     <script src="/js/dark-mode.js"></script>
-
 </html>
-

--- a/src/_includes/narrow.njk
+++ b/src/_includes/narrow.njk
@@ -18,7 +18,7 @@
     {% endif %}</title>
     <meta name="description" content="{{ description or site.description }}">
     <link rel="stylesheet" href="/css/style.css">
-    
+
     <!-- Pre-load font files -->
     <link rel="preload" href="/assets/fonts/Blanco-Regular.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Blanco-Medium.woff" as="font" type="font/woff" crossorigin>
@@ -26,7 +26,7 @@
     <link rel="preload" href="/assets/fonts/Blanco-Italic.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Blanco-MediumItalic.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/assets/fonts/Blanco-MediumItalic.woff" as="font" type="font/woff" crossorigin>
-    
+
     <link rel="preload" href="/assets/fonts/Degular-Regular.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-Regular.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-Medium.woff2" as="font" type="font/woff2" crossorigin>
@@ -35,34 +35,37 @@
     <link rel="preload" href="/assets/fonts/Degular-Italic.woff" as="font" type="font/woff" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-MediumItalic.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/assets/fonts/Degular-MediumItalic.woff" as="font" type="font/woff" crossorigin>
-    
+
     <meta name="theme-color" content="#fcfaf6">
-    
+
     <!-- RSS Feeds -->
     <link rel="alternate" type="application/atom+xml" title="Journal Feed" href="/journal/feed.xml">
     <link rel="alternate" type="application/atom+xml" title="Links Feed" href="/links/feed.xml">
     <!--<script defer src="https://cloud.umami.is/script.js" data-website-id="5a0a578b-bf79-4578-96ef-373454590774"></script>-->
 </head>
-<body class="min-h-screen bg-beige dark:bg-[#222] text-gray-900 dark:text-gray-100 font-sans overflow-x-hidden {{ bodyClass }}">
-   {% include "header.njk" %}
+<body class="min-h-screen bg-beige dark:bg-[#222] text-gray-900 dark:text-gray-100 font-sans overflow-x-hidden">
+    <!-- Background layer -->
+    <div id="page-background" class="fixed inset-0 -z-10 {{ bodyClass }}"></div>
 
-    <nav class="fixed bottom-4 left-4 right-4 z-50 sm:bottom-6 sm:left-6 sm:right-auto">
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg py-4 px-4 sm:bg-transparent sm:dark:bg-transparent sm:border-0 sm:p-0 relative overflow-hidden">
-            <div class="absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white dark:from-gray-900 to-transparent pointer-events-none sm:hidden"></div>
-            {% include "navigation.njk" %}
-        </div>
-    </nav>
-    
-    <main class="ml-0 lg:ml-80 mr-0 lg:mr-32 pt-20 px-6 lg:px-12 flex-1 flex justify-end max-w-[1400px]">
-        <div class="w-full max-w-[1400px]">
-            <div class="w-full max-w-xl ml-auto prose prose-lg font-serif pt-[25vh] pb-32 dark:prose-invert">
-                {{ content | safe }}
+    <!-- Content wrapper -->
+    <div id="page-content">
+    {% include "header.njk" %}
+
+        <nav class="fixed z-50 bottom-4 left-4 right-4 sm:bottom-6 sm:left-6 sm:right-auto">
+            <div class="relative px-4 py-4 overflow-hidden bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:border-gray-700 sm:bg-transparent sm:dark:bg-transparent sm:border-0 sm:p-0">
+                <div class="absolute inset-y-0 right-0 w-12 pointer-events-none bg-gradient-to-l from-white dark:from-gray-900 to-transparent sm:hidden"></div>
+                {% include "navigation.njk" %}
             </div>
-        </div>
-    </main>
+        </nav>
 
-    
+        <main class="ml-0 lg:ml-80 mr-0 lg:mr-32 pt-20 px-6 lg:px-12 flex-1 flex justify-end max-w-[1400px]">
+            <div class="w-full max-w-[1400px]">
+                <div class="w-full max-w-xl ml-auto prose prose-lg font-serif pt-[25vh] pb-32 dark:prose-invert">
+                    {{ content | safe }}
+                </div>
+            </div>
+        </main>
+    </div>
+
     <script src="/js/dark-mode.js"></script>
-
 </html>
-

--- a/src/_includes/narrow.njk
+++ b/src/_includes/narrow.njk
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<script>
+	  // Apply dark mode immediately to prevent flash
+	  if (localStorage.theme === 'dark' ||
+	    (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+	    document.documentElement.classList.add('dark');
+	  }
+	</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
@@ -43,7 +51,7 @@
     <link rel="alternate" type="application/atom+xml" title="Links Feed" href="/links/feed.xml">
     <!--<script defer src="https://cloud.umami.is/script.js" data-website-id="5a0a578b-bf79-4578-96ef-373454590774"></script>-->
 </head>
-<body class="min-h-screen bg-beige dark:bg-[#222] text-gray-900 dark:text-gray-100 font-sans overflow-x-hidden">
+<body class="min-h-screen font-sans overflow-x-hidden">
     <!-- Background layer -->
     <div id="page-background" class="fixed inset-0 -z-10 {{ bodyClass }}"></div>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+
+/* Define animation variables */
+:root {
+	--view-transition-duration: 1s;
+	--view-transition-easing: linear;
+}
+
 @view-transition {
     navigation: auto;
 }
@@ -11,10 +18,16 @@
     transform: translateZ(0);
 }
 
+html.dark #page-background {
+	view-transition-name: none;
+	background-color: #222 !important;
+}
+
 #page-content {
     view-transition-name: content;
     position: relative;
     min-height: 100vh;
+    @apply text-gray-900 dark:text-gray-100;
 }
 
 /* Reset transforms during capture */
@@ -40,8 +53,8 @@
 
 /* Smooth background color morph */
 ::view-transition-group(bg) {
-    animation-duration: 1s;
-    animation-timing-function: linear;
+    animation-duration: var(--view-transition-duration);
+    animation-timing-function: var(--view-transition-easing);
 }
 
 /* Make sure the rest of the element's don't animate or scroll */

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2,6 +2,53 @@
 @tailwind components;
 @tailwind utilities;
 
+@view-transition {
+    navigation: auto;
+}
+
+#page-background {
+    view-transition-name: bg;
+    transform: translateZ(0);
+}
+
+#page-content {
+    view-transition-name: content;
+    position: relative;
+    min-height: 100vh;
+}
+
+/* Reset transforms during capture */
+::view-transition-old(content) {
+    transform: none !important;
+    position: fixed !important;
+    inset: 0 !important;
+}
+
+/* Hide old content immediately */
+::view-transition-old(content) {
+    animation: none;
+    opacity: 0;
+}
+
+/* Show new content immediately */
+::view-transition-new(content) {
+    animation: none;
+    opacity: 1;
+    transform: translateY(0) !important;
+    top: 0 !important;
+}
+
+/* Smooth background color morph */
+::view-transition-group(bg) {
+    animation-duration: 1s;
+    animation-timing-function: linear;
+}
+
+/* Make sure the rest of the element's don't animate or scroll */
+::view-transition-group(*) {
+    animation: none;
+}
+
 /* Font declarations for Blanco */
 @font-face {
     font-family: 'Blanco';


### PR DESCRIPTION
Adds simple page transitions (fades background, instantly transitions content). Fun little experiment, feel free to use or feel free to throw it in a dumpster. Animation duration and easing needs some love.

Can only achieved with the View Transitions APIs via a separate element for the background, and by adding a content container. Without these, all content fades with the background, which feels very heavy handed. This might make it a little bit more cumbersome to do some responsive layouts (the content container needs to be targeted instead of the body).

Only tested in Chromium (Arc) on desktop.