### PR TITLE
Fix title sizing across pages

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -670,6 +670,8 @@ ul.links li h2 {
     margin-top: 1.125rem;
     font-family: theme('fontFamily.serif');
     font-weight: 500;
+    font-size: 1.875rem;
+    line-height: 1.2;
     text-wrap: balance;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -670,13 +670,9 @@ ul.links li h2 {
     margin-top: 1.125rem;
     font-family: theme('fontFamily.serif');
     font-weight: 500;
-    font-size: 1.875rem;
+    font-size: 1.5rem !important;
     line-height: 1.2;
     text-wrap: balance;
-}
-
-ul.links.newsletter li h2 {
-    font-size: 1.5rem;
 }
 
 ul.links li a.no-underline {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -675,6 +675,10 @@ ul.links li h2 {
     text-wrap: balance;
 }
 
+ul.links.newsletter li h2 {
+    font-size: 1.5rem;
+}
+
 ul.links li a.no-underline {
     text-decoration: none !important;
     background: none !important;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -742,6 +742,10 @@ ul.newsletter h2 {
 }
 
 /* Journal index list */
+.journal-entry-title {
+    line-height: 1.2;
+}
+
 .journal-entry,
 .journal-entry *,
 .prose .journal-entry,

--- a/src/journal.njk
+++ b/src/journal.njk
@@ -20,7 +20,7 @@ permalink: journal/index.html
   {% endif %}
 
   <a href="{{ post.data.external_url or post.url }}" class="journal-entry block border-b border-gray-950/10 dark:border-white/5 pb-5 mb-5" {% if post.data.external_url %}target="_blank" rel="external"{% endif %}>
-    <span class="journal-entry-title font-serif text-3xl font-medium">{{ post.data.title }}</span>
+    <span class="journal-entry-title font-serif text-xl font-medium">{{ post.data.title }}</span>
     {% if post.data.description %}
     <p class="font-serif text-black/70 dark:text-white/60 mt-1 m-0">{{ post.data.description }}</p>
     {% endif %}

--- a/src/links-by-tag.njk
+++ b/src/links-by-tag.njk
@@ -23,7 +23,7 @@ eleventyComputed:
   <li class="py-3 pl-0">
     <div class="flex flex-col">
       <div class="flex items-baseline justify-between">
-        <a href="{{ post.data.external_url }}" class="text-3xl font-serif font-semibold no-underline" target="_blank" rel="external">
+        <a href="{{ post.data.external_url }}" class="text-xl font-serif font-semibold no-underline" target="_blank" rel="external">
          <h2 class="no-underline">{{ post.data.title }}</h2>
         </a>
         <span class="text-xs uppercase font-semibold tracking-widest text-gray-500 ml-4 whitespace-nowrap font-sans">

--- a/src/links.njk
+++ b/src/links.njk
@@ -21,7 +21,7 @@ permalink: "links/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumbe
   <li class="py-3 pl-0">
     <div class="flex flex-col">
       <div class="flex items-baseline justify-between">
-        <a href="{{ post.data.external_url }}" class="text-3xl font-serif font-semibold no-underline" target="_blank" rel="external">
+        <a href="{{ post.data.external_url }}" class="text-xl font-serif font-semibold no-underline" target="_blank" rel="external">
          <h2 class="no-underline">{{ post.data.title }}</h2>
         </a>
         <span class="text-xs uppercase font-semibold tracking-widest text-gray-500 ml-4 whitespace-nowrap font-sans">

--- a/src/newsletter.njk
+++ b/src/newsletter.njk
@@ -25,7 +25,7 @@ permalink: "newsletter/{% if pagination.pageNumber > 0 %}page/{{ pagination.page
         {% image "src" + post.data.image.src, post.data.image.alt, "(min-width: 768px) 50vw, 100vw", "w-full" %}
       {% endif %}
       <div class="flex items-baseline justify-between">
-        <a href="{{ post.data.external_url }}" class="text-3xl font-serif font-semibold no-underline" target="_blank" rel="external">
+        <a href="{{ post.data.external_url }}" class="text-xl font-serif font-semibold no-underline" target="_blank" rel="external">
          <h2 class="no-underline">{{ post.data.title }}</h2>
         </a>
         <span class="text-xs uppercase tracking-widest text-gray-500 ml-4 whitespace-nowrap font-sans">


### PR DESCRIPTION

- Fix Links/Newsletter titles appearing too small on mobile by setting an explicit `font-size: 1.875rem` (30px) on `ul.links li h2`, overriding the `prose-lg` plugin's h2 cascade
- Fix Journal titles being too large on desktop by reducing from `text-3xl` to `text-xl` (24px), appropriate for its compact listing format with descriptions

